### PR TITLE
add an option `styleLibrary`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Via `.babelrc` or babel-loader.
   - componentB
     - index.js
 ```
+or 
+```
+- lib
+  - theme-custom // 'styleLibrary.name'
+    - base.css // if styleLibrary.base true
+    - index.css // required
+    - componentA.css // default 
+    - componentB.css
+  - theme-material
+    - componentA
+      -index.css  // styleLibrary.path  [module]/index.css
+    - componentB
+      -index.css
+  - componentA
+    - index.js
+  - componentB
+    - index.js
+```
 
 ### options
 
@@ -102,6 +120,14 @@ Via `.babelrc` or babel-loader.
 - `["component", { "libraryName": "component" }]`: module name
 - `["component", { "styleLibraryName": "theme_package" }]`: style module name
 - `["component", { "styleLibraryName": "~independent_theme_package" }]`: Import a independent theme package
+- `["component", { "styleLibrary": {} }]`: Import a independent theme package with more config
+  ```
+  styleLibrary: {
+    "name": "xxx", // same with styleLibraryName
+    "base": true,  // if theme package has a base.css
+    "path": "[module]/index.css"  // the style path. e.g. module Alert =>  alert/index.css
+  }
+  ```
 - `["component", { "style": true }]`: import js and css from 'style.css'
 - `["component", { "style": cssFilePath }]`: import style css from filePath
 - `["component", { "libDir": "lib" }]`: lib directory

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ or
   styleLibrary: {
     "name": "xxx", // same with styleLibraryName
     "base": true,  // if theme package has a base.css
-    "path": "[module]/index.css"  // the style path. e.g. module Alert =>  alert/index.css
+    "path": "[module]/index.css",  // the style path. e.g. module Alert =>  alert/index.css
+    "mixin": true  // if theme-package not found css file, then use [libraryName]'s css file
   }
   ```
 - `["component", { "style": true }]`: import js and css from 'style.css'

--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,5 @@
 const resolve = require('path').resolve;
+const isExist = require('fs').existsSync;
 const cache = {};
 const cachePath = {};
 const importAll = {};
@@ -39,6 +40,7 @@ export default function (defaultLibraryName) {
         let _root = root;
         let isBaseStyle = true;
         let modulePathTpl;
+        let mixin = false;
 
         if (root) {
           _root = `/${root}`;
@@ -52,12 +54,14 @@ export default function (defaultLibraryName) {
         } else {
           path = `${libraryName}/${libDir}/${camel2Dash(methodName)}`;
         }
+        const _path = path;
 
         selectedMethods[methodName] = file.addImport(path, 'default');
         if (styleLibrary && typeof styleLibrary === 'object') {
           styleLibraryName = styleLibrary.name;
           isBaseStyle = styleLibrary.base;
           modulePathTpl = styleLibrary.path;
+          mixin = styleLibrary.mixin;
         }
         if (styleLibraryName) {
           if (!cachePath[libraryName]) {
@@ -84,6 +88,9 @@ export default function (defaultLibraryName) {
                 path = `${cachePath[libraryName]}/${modulePath}`;
               } else {
                 path = `${cachePath[libraryName]}/${camel2Dash(methodName)}.css`;
+              }
+              if (mixin && !isExist(path)) {
+                path = style === true ? `${_path}/style.css` : `${_path}/${style}`;
               }
               if (isBaseStyle) {
                 file.addImport(`${cachePath[libraryName]}/base.css`, 'default');

--- a/src/core.js
+++ b/src/core.js
@@ -31,10 +31,14 @@ export default function (defaultLibraryName) {
         const {
           libDir = 'lib',
           libraryName = defaultLibraryName,
-          styleLibraryName, style,
+          style,
+          styleLibrary,
           root = '',
         } = options;
+        let styleLibraryName = options.styleLibraryName;
         let _root = root;
+        let isBaseStyle = true;
+        let modulePathTpl;
 
         if (root) {
           _root = `/${root}`;
@@ -50,7 +54,11 @@ export default function (defaultLibraryName) {
         }
 
         selectedMethods[methodName] = file.addImport(path, 'default');
-
+        if (styleLibrary && typeof styleLibrary === 'object') {
+          styleLibraryName = styleLibrary.name;
+          isBaseStyle = styleLibrary.base;
+          modulePathTpl = styleLibrary.path;
+        }
         if (styleLibraryName) {
           if (!cachePath[libraryName]) {
             const themeName = styleLibraryName.replace(/^~/, '');
@@ -70,8 +78,16 @@ export default function (defaultLibraryName) {
             cache[libraryName] = 1;
           } else {
             if (cache[libraryName] !== 1) {
-              path = `${cachePath[libraryName]}/${camel2Dash(methodName)}.css`;
-              file.addImport(`${cachePath[libraryName]}/base.css`, 'default');
+              /* if set styleLibrary.path(format: [module]/module.css) */
+              if (modulePathTpl) {
+                const modulePath = modulePathTpl.replace(/\[module]/ig, camel2Dash(methodName));
+                path = `${cachePath[libraryName]}/${modulePath}`;
+              } else {
+                path = `${cachePath[libraryName]}/${camel2Dash(methodName)}.css`;
+              }
+              if (isBaseStyle) {
+                file.addImport(`${cachePath[libraryName]}/base.css`, 'default');
+              }
               cache[libraryName] = 2;
             }
           }

--- a/test/fixtures/import-theme-custom-path/actual.js
+++ b/test/fixtures/import-theme-custom-path/actual.js
@@ -1,0 +1,4 @@
+import { Button, Alert } from 'element-ui5';
+
+console.log(Button);
+console.log(Alert);

--- a/test/fixtures/import-theme-custom-path/expected.js
+++ b/test/fixtures/import-theme-custom-path/expected.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _alert = require('element-ui5/lib/theme-custom-path/alert/alert.css');
+
+var _alert2 = _interopRequireDefault(_alert);
+
+var _alert3 = require('element-ui5/lib/alert');
+
+var _alert4 = _interopRequireDefault(_alert3);
+
+var _button = require('element-ui5/lib/theme-custom-path/button/button.css');
+
+var _button2 = _interopRequireDefault(_button);
+
+var _button3 = require('element-ui5/lib/button');
+
+var _button4 = _interopRequireDefault(_button3);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_button4.default);
+console.log(_alert4.default);

--- a/test/fixtures/import-theme-custom/actual.js
+++ b/test/fixtures/import-theme-custom/actual.js
@@ -1,0 +1,4 @@
+import { Button, Alert } from 'element-ui4';
+
+console.log(Button);
+console.log(Alert);

--- a/test/fixtures/import-theme-custom/expected.js
+++ b/test/fixtures/import-theme-custom/expected.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _alert = require('element-ui4/lib/theme-custom/alert.css');
+
+var _alert2 = _interopRequireDefault(_alert);
+
+var _alert3 = require('element-ui4/lib/alert');
+
+var _alert4 = _interopRequireDefault(_alert3);
+
+var _button = require('element-ui4/lib/theme-custom/button.css');
+
+var _button2 = _interopRequireDefault(_button);
+
+var _button3 = require('element-ui4/lib/button');
+
+var _button4 = _interopRequireDefault(_button3);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_button4.default);
+console.log(_alert4.default);

--- a/test/fixtures/independent-theme-package-custom/actual.js
+++ b/test/fixtures/independent-theme-package-custom/actual.js
@@ -1,0 +1,4 @@
+import { Button, Alert } from 'element-ui6';
+
+console.log(Button);
+console.log(Alert);

--- a/test/fixtures/independent-theme-package-custom/expected.js
+++ b/test/fixtures/independent-theme-package-custom/expected.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var _alert = require('__theme__/theme/alert/alert.css');
+
+var _alert2 = _interopRequireDefault(_alert);
+
+var _alert3 = require('element-ui6/lib/alert');
+
+var _alert4 = _interopRequireDefault(_alert3);
+
+var _button = require('__theme__/theme/button/button.css');
+
+var _button2 = _interopRequireDefault(_button);
+
+var _base = require('__theme__/theme/base.css');
+
+var _base2 = _interopRequireDefault(_base);
+
+var _button3 = require('element-ui6/lib/button');
+
+var _button4 = _interopRequireDefault(_button3);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_button4.default);
+console.log(_alert4.default);

--- a/test/fixtures/independent-theme-package-mixin/actual.js
+++ b/test/fixtures/independent-theme-package-mixin/actual.js
@@ -1,0 +1,4 @@
+import { Button, Alert } from 'element-ui7';
+
+console.log(Button);
+console.log(Alert);

--- a/test/fixtures/independent-theme-package-mixin/expected.js
+++ b/test/fixtures/independent-theme-package-mixin/expected.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _style = require('element-ui7/lib/alert/style.css');
+
+var _style2 = _interopRequireDefault(_style);
+
+var _alert = require('element-ui7/lib/alert');
+
+var _alert2 = _interopRequireDefault(_alert);
+
+var _style3 = require('element-ui7/lib/button/style.css');
+
+var _style4 = _interopRequireDefault(_style3);
+
+var _button = require('element-ui7/lib/button');
+
+var _button2 = _interopRequireDefault(_button);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+console.log(_button2.default);
+console.log(_alert2.default);

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -51,6 +51,31 @@ describe('index', () => {
         ]];
       }
 
+      if (caseName === 'import-theme-custom') {
+        cssPlugin = [plugin, [
+          {
+            libraryName: 'element-ui4',
+            styleLibrary: {
+              base: false,
+              name: 'theme-custom',
+            },
+          },
+        ]];
+      }
+
+      if (caseName === 'import-theme-custom-path') {
+        cssPlugin = [plugin, [
+          {
+            libraryName: 'element-ui5',
+            styleLibrary: {
+              base: false,
+              name: 'theme-custom-path',
+              path: '[module]/[module].css',
+            },
+          },
+        ]];
+      }
+
       if (caseName === 'import-theme-all-compo') {
         cssPlugin = [plugin, [
           {
@@ -66,6 +91,20 @@ describe('index', () => {
           {
             libraryName: 'element-ui3',
             styleLibraryName: '~theme',
+          },
+        ]];
+      }
+
+      if (caseName === 'independent-theme-package-custom') {
+        expected = expected.replace(/__theme__/g, process.cwd());
+        cssPlugin = [plugin, [
+          {
+            libraryName: 'element-ui6',
+            styleLibrary: {
+              base: true,
+              name: '~theme',
+              path: '[module]/[module].css',
+            },
           },
         ]];
       }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -109,6 +109,20 @@ describe('index', () => {
         ]];
       }
 
+      if (caseName === 'independent-theme-package-mixin') {
+        cssPlugin = [plugin, [
+          {
+            libraryName: 'element-ui7',
+            styleLibrary: {
+              mixin: true,
+              name: '~theme',
+              path: '[module]/[module].css',
+            },
+            style: true,
+          },
+        ]];
+      }
+
       if (caseName === 'custom-css-filename') {
         cssPlugin = [plugin, { style: 'style.css' }];
       }


### PR DESCRIPTION
添加自定义主题配置配置项`styleLibrary`，其格式为：
```
["component", { "styleLibrary": {
    "name": "theme_package", // ~independent_theme_package 格式形同styleLibraryName
    "base": true,  // 是否需要base.css文件
    "path": "[module]/index.css",  // 模块样式文件的路径，支持`[module]/index.css` 
    "mixin": true  // 如何自定义主题中没有相关的样式文件，则使用`libraryName`配置的中的，主要此项需要 和 style 配置一块使用 
}}]
```