### PR TITLE
fix: support multiple reference when preset-env modules is commonjs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -112,7 +112,7 @@ module.exports = function core(defaultLibraryName) {
             }
           }
 
-          addDefault(file.path, path, { nameHint: methodName });
+          addSideEffect(file.path, path, { nameHint: methodName });
         } else {
           if (style === true) {
             addSideEffect(file.path, `${path}/style${ext}`);
@@ -121,7 +121,7 @@ module.exports = function core(defaultLibraryName) {
           }
         }
       }
-      return selectedMethods[methodName];
+      return Object.assign({}, selectedMethods[methodName]);
     }
 
     function buildExpressionHandler(node, props, path, state) {


### PR DESCRIPTION
[ant-design/Fix multiple imports](https://github.com/ant-design/babel-plugin-import/pull/212)
https://github.com/ElementUI/babel-plugin-component/issues/59
https://github.com/ElementUI/babel-plugin-component/issues/56