### PR TITLE
fix: transform commonjs

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -121,7 +121,7 @@ module.exports = function core(defaultLibraryName) {
           }
         }
       }
-      return selectedMethods[methodName];
+      return Object.assign({}, selectedMethods[methodName]);
     }
 
     function buildExpressionHandler(node, props, path, state) {

--- a/test/fixtures/transform-commonjs/actual.js
+++ b/test/fixtures/transform-commonjs/actual.js
@@ -1,0 +1,7 @@
+import { Button } from 'element-ui';
+
+export default {
+  components: {
+    [Button.name]: Button
+  }
+}

--- a/test/fixtures/transform-commonjs/expected.js
+++ b/test/fixtures/transform-commonjs/expected.js
@@ -1,0 +1,19 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+require("element-ui/lib/button/style.css");
+
+var _button = _interopRequireDefault(require("element-ui/lib/button"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var _default = {
+  components: _defineProperty({}, _button.default.name, _button.default)
+};
+exports.default = _default;

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -133,6 +133,13 @@ describe('index', () => {
         }];
       }
 
+      if (caseName === 'transform-commonjs') {
+        cssPlugin = [
+          [plugin], 
+          ['@babel/plugin-transform-modules-commonjs']
+        ];
+      }
+
       const actual = transformFileSync(actualFile, {
         presets: ['@babel/react'],
         plugins: cssPlugin && Array.isArray(cssPlugin[1]) ? cssPlugin : [cssPlugin || plugin],


### PR DESCRIPTION
## Problem

[@babel/plugin-transform-modules-commonjs](https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-modules-commonjs) used by [@babel/preset-env
](https://babeljs.io/docs/en/babel-preset-env) for transform modules to commonjs will save which nodes have already traverse and skip them when the next traverse(https://github.com/babel/babel/blob/10978bb65a4b4e8874ca8dd3054b8c31b5838b7f/packages/babel-helper-module-transforms/src/rewrite-live-references.js#L175)

`@babel/plugin-transform-modules-commonjs` will save every traversed reference of node, so if the references of node are same, the babel will skip to transform the node. This is the problem of this issue.

## Resolve

Just clone object to prevent use same object reference.